### PR TITLE
Remove errant close-parentheses

### DIFF
--- a/gsw_internal_const.h
+++ b/gsw_internal_const.h
@@ -9,7 +9,7 @@
 /*
 ** The following hack is used to ensure that gcc (and gcc emulating compilers
 ** such as Macosx clang) do not emit unused variable warning messages.
-*/)
+*/
 #ifdef __GNUC__
 #define UNUSED __attribute__ ((unused))
 #else


### PR DESCRIPTION
Won't compile on my mac or my CentOS VM with the parens there, but compiles and tests fine on my mac if I remove it. (Build on CentOS machine still fails for `make all` due to lack of required python tools, but is fine for `make library`.)