### PR TITLE
BUG: fix include syntax for local include files

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,7 +36,7 @@
            libdirname:=	lib
   endif
                CFLAGS:=	-O3 -Wall
-            CINCLUDES:=	-I.
+            CINCLUDES:=
               Library:=	libgswteos-10.so
            LibVersion:=	$(shell echo $(STSVersion) | \
 			awk -F . '{printf "%s.%s\n",$$1,$$2}')
@@ -104,7 +104,7 @@ dist:
 	rm -f gsw_c_v*;
 	ln -s . $(ZIPLINK)
 	zip -r $(ZIPLINK).zip $(addprefix $(ZIPLINK)/,$(ZIPFILES))
-	
+
 clean:
 	rm -f $(Program) $(Library) $(Library).$(LibVersion) $($(Library)_OBJS)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #  $Id: Makefile,v 1e5e75c749c2 2015/08/08 22:03:51 fdelahoyde $
 #
                CFLAGS:=	-O3
-            CINCLUDES:=	-I.
+            CINCLUDES:=
               Library:=	libgswteos-10.so
               Program:=	gsw_check
       $(Program)_SRCS:=	gsw_check_functions.c \

--- a/gsw_check_functions.c
+++ b/gsw_check_functions.c
@@ -5,8 +5,8 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
-#include <gswteos-10.h>
-#include <gsw_check_data.c>
+#include "gswteos-10.h"
+#include "gsw_check_data.c"
 
 #define test_func(name, arglist, value, var) \
 	for (i=0; i<count; i++) { \
@@ -74,7 +74,7 @@ typedef struct gsw_error_info {
 		limit,
 		rlimit;
 }	gsw_error_info;
-	
+
 void report(char *funcname, char *varname, gsw_error_info *errs);
 void check_accuracy(char *funcname, double accuracy, char *varname,
 			int count, double *calcval, double *refval);

--- a/gsw_oceanographic_toolbox-head
+++ b/gsw_oceanographic_toolbox-head
@@ -11,7 +11,7 @@
  Gibbs SeaWater (GSW) Oceanographic Toolbox of TEOS-10 (Fortran)
 ==========================================================================
 
- This is a subset of functions contained in the Gibbs SeaWater (GSW) 
+ This is a subset of functions contained in the Gibbs SeaWater (GSW)
  Oceanographic Toolbox of TEOS-10.
 
  Version 1.0 written by David Jackett
@@ -46,6 +46,6 @@
 
 ==========================================================================
 */
-#include <gswteos-10.h>
-#include <gsw_internal_const.h>
+#include "gswteos-10.h"
+#include "gsw_internal_const.h"
 

--- a/gsw_oceanographic_toolbox.c
+++ b/gsw_oceanographic_toolbox.c
@@ -1,5 +1,5 @@
 /*
-**  $Id: gsw_oceanographic_toolbox.c,v 9248219e2c8d 2016/08/29 23:43:19 fdelahoyde $
+**  $Id: gsw_oceanographic_toolbox-head,v c61271a7810d 2016/08/19 20:04:03 fdelahoyde $
 **  Version: 3.05.0-3
 **
 **  This is a translation of the original f90 source code into C
@@ -11,7 +11,7 @@
  Gibbs SeaWater (GSW) Oceanographic Toolbox of TEOS-10 (Fortran)
 ==========================================================================
 
- This is a subset of functions contained in the Gibbs SeaWater (GSW) 
+ This is a subset of functions contained in the Gibbs SeaWater (GSW)
  Oceanographic Toolbox of TEOS-10.
 
  Version 1.0 written by David Jackett
@@ -46,8 +46,8 @@
 
 ==========================================================================
 */
-#include <gswteos-10.h>
-#include <gsw_internal_const.h>
+#include "gswteos-10.h"
+#include "gsw_internal_const.h"
 
 /*
 !==========================================================================
@@ -3968,7 +3968,7 @@ gsw_geo_strf_dyn_height_pc(double *sa, double *ct, double *delta_p, int n_levels
 {
 	int	i, np;
 	double	*delta_h, delta_h_half, dyn_height_deep=0.0,
-		prv_dyn_height_deep, *p_deep, *p_shallow;
+		*p_deep, *p_shallow;
 
 	for (i=0; i<n_levels; i++)
 	    if (delta_p[i] < 0.0)
@@ -3985,8 +3985,7 @@ gsw_geo_strf_dyn_height_pc(double *sa, double *ct, double *delta_p, int n_levels
 	}
 
 	for (i=0; i<np; i++) {
-	    prv_dyn_height_deep = (i==0)? -delta_h[0]: dyn_height_deep;
-	    dyn_height_deep = prv_dyn_height_deep - delta_h[i];
+	    dyn_height_deep = dyn_height_deep - delta_h[i];
 		/* This is Phi minus Phi_0 of Eqn. (3.32.2) of IOC et al. (2010).*/
 	    p_mid[i] = 0.5*(p_shallow[i]  + p_deep[i]);
 	    delta_h_half = gsw_enthalpy_diff(sa[i],ct[i],p_mid[i],p_deep[i]);

--- a/gsw_saar.c
+++ b/gsw_saar.c
@@ -4,9 +4,9 @@
 **
 **  GSW TEOS-10 V3.05
 */
-#include <gswteos-10.h>
-#include <gsw_internal_const.h>
-#include <gsw_saar_data.c>
+#include "gswteos-10.h"
+#include "gsw_internal_const.h"
+#include "gsw_saar_data.c"
 
 static double
 gsw_sum(double *x, int n)
@@ -29,7 +29,7 @@ function gsw_saar(p,long,lat)
 ! Calculates the Absolute Salinity Anomaly Ratio, SAAR.
 !
 ! p      : sea pressure                                    [dbar]
-! long   : longitude                                       [deg E]     
+! long   : longitude                                       [deg E]
 ! lat    : latitude                                        [deg N]
 !
 ! gsw_saar : Absolute Salinity Anomaly Ratio               [unitless]
@@ -79,7 +79,7 @@ gsw_saar(double p, double lon, double lat)
 	if (p > p_ref[(int)(ndepth_max)-1])
 	    p	= p_ref[(int)(ndepth_max)-1];
 	indz0	= gsw_util_indx(p_ref,nz,p);
-    
+
 	r1	= (lon-longs_ref[indx0])/(longs_ref[indx0+1]-longs_ref[indx0]);
 	s1	= (lat-lats_ref[indy0])/(lats_ref[indy0+1]-lats_ref[indy0]);
 	t1	= (p-p_ref[indz0])/(p_ref[indz0+1]-p_ref[indz0]);
@@ -134,7 +134,7 @@ function gsw_deltasa_atlas(p,lon,lat)
 ! Calculates the Absolute Salinity Anomaly atlas value, delta_SA_atlas.
 !
 ! p      : sea pressure                                    [dbar]
-! lon    : longiture                                       [deg E]     
+! lon    : longiture                                       [deg E]
 ! lat    : latitude                                        [deg N]
 !
 ! deltasa_atlas : Absolute Salinity Anomaly atlas value    [g/kg]
@@ -184,7 +184,7 @@ gsw_deltasa_atlas(double p, double lon, double lat)
 	if (p > p_ref[(int)(ndepth_max)-1])
 	    p	= p_ref[(int)(ndepth_max)-1];
 	indz0	= gsw_util_indx(p_ref,nz,p);
-    
+
 	r1	= (lon-longs_ref[indx0])/
 			(longs_ref[indx0+1]-longs_ref[indx0]);
 	s1	= (lat-lats_ref[indy0])/


### PR DESCRIPTION
Local files such as gswteos-10.h should be included using
quote syntax rather than the angle-bracket syntax which is
for system files.  Fixing this is needed for wrapping the
library in R and Python, when not relying on the library
having been installed at the system level.