### PR TITLE
switch from qsort_[rs] to qsort

### DIFF
--- a/gsw_oceanographic_toolbox.c
+++ b/gsw_oceanographic_toolbox.c
@@ -1,6 +1,6 @@
 /*
 **  $Id: gsw_oceanographic_toolbox-head,v c61271a7810d 2016/08/19 20:04:03 fdelahoyde $
-**  Version: 3
+**  Version: 3.05.0-4
 **
 **  This is a translation of the original f90 source code into C
 **  by the Shipboard Technical Support Computing Resources group
@@ -10614,11 +10614,6 @@ gsw_util_linear_interp(int nx, double *x, int ny, double *y, int nxi,
 pure function gsw_util_sort_real (rarray) result(iarray)
 */
 
-/*
-**  Sort the double array rarray into ascending value sequence
-**  returning an index array of the sorted result.  This function
-**  is thread-safe.
-*/
 typedef struct {
     double d;
     int i;
@@ -10629,24 +10624,25 @@ int compareDI(const void *a, const void *b)
     DI *A = (DI*)a;
     DI *B = (DI*)b;
     if (A->d < B->d)
-        return(-1);
-    else if (A->d > B->d)
-        return(1);
-    else if (A->i < B->i)
-        return(-1);
-    else if (A->i > B->i)
-        return(1);
-    else 
-        return(0); // cannot occur
+        return (-1);
+    if (A->d > B->d)
+        return (1);
+    if (A->i < B->i)
+        return (1);
+    return (-1);
 }
 
-
+/*
+**  Sort the double array rarray into ascending value sequence
+**  returning an index array of the sorted result.  This function
+**  is thread-safe.
+*/
 void
 gsw_util_sort_real(double *rarray, int nx, int *iarray)
 {
 	int	i;
         DI* di = (DI*)malloc(nx*sizeof(DI));
-        for (i = 0; i < nx; i++) {
+        for (i=0; i<nx; i++) {
             di[i].d = rarray[i];
             di[i].i = i;
         }

--- a/gsw_oceanographic_toolbox.c
+++ b/gsw_oceanographic_toolbox.c
@@ -10615,21 +10615,28 @@ pure function gsw_util_sort_real (rarray) result(iarray)
 */
 
 typedef struct {
-    double d;
-    int i;
+	double	d;
+	int	i;
 } DI;
 
-int compareDI(const void *a, const void *b)
+/*
+ * Rank two items, by value if possible,
+ * and by inverse index, if the values are
+ * equal.
+ * FIXME: decide if index method matches docs.
+ */
+int
+compareDI(const void *a, const void *b)
 {
-    DI *A = (DI*)a;
-    DI *B = (DI*)b;
-    if (A->d < B->d)
-        return (-1);
-    if (A->d > B->d)
-        return (1);
-    if (A->i < B->i)
-        return (1);
-    return (-1);
+	DI	*A = (DI*)a;
+	DI	*B = (DI*)b;
+	if (A->d < B->d)
+		return (-1);
+	if (A->d > B->d)
+		return (1);
+	if (A->i < B->i)
+		return (1);
+	return (-1);
 }
 
 /*
@@ -10641,15 +10648,15 @@ void
 gsw_util_sort_real(double *rarray, int nx, int *iarray)
 {
 	int	i;
-        DI* di = (DI*)malloc(nx*sizeof(DI));
-        for (i=0; i<nx; i++) {
-            di[i].d = rarray[i];
-            di[i].i = i;
-        }
-        qsort(di, nx, sizeof(DI), compareDI);
+	DI* di = (DI*)malloc(nx*sizeof(DI));
+	for (i=0; i<nx; i++) {
+		di[i].d = rarray[i];
+		di[i].i = i;
+	}
+	qsort(di, nx, sizeof(DI), compareDI);
 	for (i=0; i<nx; i++)
-	    iarray[i] = di[i].i;
-        free(di);
+		iarray[i] = di[i].i;
+	free(di);
 }
 /*
 !==========================================================================

--- a/gsw_oceanographic_toolbox.c
+++ b/gsw_oceanographic_toolbox.c
@@ -10614,54 +10614,48 @@ gsw_util_linear_interp(int nx, double *x, int ny, double *y, int nxi,
 pure function gsw_util_sort_real (rarray) result(iarray)
 */
 
-#if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
-         defined __FREEBSD__ || defined __BSD__ || \
-	 defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
-static int
-compare(void *rarray, const void *p1, const void *p2)
-#else
-
-extern void qsort_r(void *, size_t, size_t, int (*)(const void *, const void *,
-			void *), void *);
-static int
-compare(const void *p1, const void *p2, void *rarray)
-#endif
-{
-	double	*rdata = rarray;
-	if (rdata[*(int *)p1] < rdata[*(int *)p2])
-	    return (-1);
-	if (rdata[*(int *)p1] > rdata[*(int *)p2])
-	    return (1);
-    /*
-    **  Note that the library functions using this utility
-    **  depend on the fact that for replicate values in rdata
-    **  the indexes are returned in descending sequence.
-    */
-	if (*(int *)p1 < *(int *)p2)
-	    return (1);
-	return (0);
-}
-
 /*
 **  Sort the double array rarray into ascending value sequence
 **  returning an index array of the sorted result.  This function
 **  is thread-safe.
 */
+typedef struct {
+    double d;
+    int i;
+} DI;
+
+int compareDI(const void *a, const void *b)
+{
+    DI *A = (DI*)a;
+    DI *B = (DI*)b;
+    if (A->d < B->d)
+        return(-1);
+    else if (A->d > B->d)
+        return(1);
+    else if (A->i < B->i)
+        return(-1);
+    else if (A->i > B->i)
+        return(1);
+    else {
+        fprintf(stderr, "programming error in compareXI function\n");
+        exit(1);
+    }
+}
+
+
 void
 gsw_util_sort_real(double *rarray, int nx, int *iarray)
 {
 	int	i;
-
+        DI* di = (DI*)malloc(nx*sizeof(DI));
+        for (i = 0; i < nx; i++) {
+            di[i].d = rarray[i];
+            di[i].i = i;
+        }
+        qsort(di, nx, sizeof(DI), compareDI);
 	for (i=0; i<nx; i++)
-	    iarray[i] = i;
-#if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
-         defined __FREEBSD__ || defined __BSD__ )
-	qsort_r(iarray, nx, sizeof (int), (void *)rarray, compare);
-#elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
-	qsort_s(iarray, nx, sizeof (int), compare, (void *)rarray);
-#else
-	qsort_r(iarray, nx, sizeof (int), compare, (void *)rarray);
-#endif
+	    iarray[i] = di[i].i;
+        free(di);
 }
 /*
 !==========================================================================

--- a/gsw_oceanographic_toolbox.c
+++ b/gsw_oceanographic_toolbox.c
@@ -10636,10 +10636,8 @@ int compareDI(const void *a, const void *b)
         return(-1);
     else if (A->i > B->i)
         return(1);
-    else {
-        fprintf(stderr, "programming error in compareXI function\n");
-        exit(1);
-    }
+    else 
+        return(0); // cannot occur
 }
 
 

--- a/toolbox/gsw_util_sort_real.c
+++ b/toolbox/gsw_util_sort_real.c
@@ -3,21 +3,28 @@ pure function gsw_util_sort_real (rarray) result(iarray)
 */
 
 typedef struct {
-    double d;
-    int i;
+	double	d;
+	int	i;
 } DI;
 
-int compareDI(const void *a, const void *b)
+/*
+ * Rank two items, by value if possible,
+ * and by inverse index, if the values are
+ * equal.
+ * FIXME: decide if index method matches docs.
+ */
+int
+compareDI(const void *a, const void *b)
 {
-    DI *A = (DI*)a;
-    DI *B = (DI*)b;
-    if (A->d < B->d)
-        return (-1);
-    if (A->d > B->d)
-        return (1);
-    if (A->i < B->i)
-        return (1);
-    return (-1);
+	DI	*A = (DI*)a;
+	DI	*B = (DI*)b;
+	if (A->d < B->d)
+		return (-1);
+	if (A->d > B->d)
+		return (1);
+	if (A->i < B->i)
+		return (1);
+	return (-1);
 }
 
 /*
@@ -29,13 +36,13 @@ void
 gsw_util_sort_real(double *rarray, int nx, int *iarray)
 {
 	int	i;
-        DI* di = (DI*)malloc(nx*sizeof(DI));
-        for (i=0; i<nx; i++) {
-            di[i].d = rarray[i];
-            di[i].i = i;
-        }
-        qsort(di, nx, sizeof(DI), compareDI);
+	DI* di = (DI*)malloc(nx*sizeof(DI));
+	for (i=0; i<nx; i++) {
+		di[i].d = rarray[i];
+		di[i].i = i;
+	}
+	qsort(di, nx, sizeof(DI), compareDI);
 	for (i=0; i<nx; i++)
-	    iarray[i] = di[i].i;
-        free(di);
+		iarray[i] = di[i].i;
+	free(di);
 }


### PR DESCRIPTION
Switching to `qsort` instead of one of the three alternatives has the advantage of making the code universal across compilers and machines, removing the need for machine-specific `#if` code blocks.  Those blocks are brittle to the addition of new machines/compilers to the support list.

This has been discussed at https://github.com/TEOS-10/GSW-R/issues/41#issuecomment-320594946