### PR TITLE
p_from_z and z_from_p: add two arguments

### DIFF
--- a/gsw_check_functions.c
+++ b/gsw_check_functions.c
@@ -156,8 +156,8 @@ main(int argc, char **argv)
         test_func(ct_from_pt, (sa[i],pt[i]), value,ct_from_pt);
         test_func(pt0_from_t, (sa[i],t[i],p[i]), value,pt0_from_t);
         test_func(pt_from_t, (sa[i],t[i],p[i],pref[0]), value,pt_from_t);
-        test_func(z_from_p, (p[i],lat[i]), z,z_from_p);
-        test_func(p_from_z, (z[i],lat[i]), value,p_from_z);
+        test_func(z_from_p, (p[i],lat[i], 0.0, 0.0), z,z_from_p);
+        test_func(p_from_z, (z[i],lat[i], 0.0, 0.0), value,p_from_z);
         test_func(entropy_from_pt, (sa[i],pt[i]), entropy,entropy_from_pt);
         test_func(pt_from_entropy, (sa[i],entropy[i]), value,pt_from_entropy);
         test_func(ct_from_entropy, (sa[i],entropy[i]), value,ct_from_entropy);

--- a/gsw_oceanographic_toolbox.c
+++ b/gsw_oceanographic_toolbox.c
@@ -5061,7 +5061,7 @@ gsw_grav(double lat, double p)
         sin2    = x*x;
         gs      = 9.780327*(1.0 + (5.2792e-3 + (2.32e-5*sin2))*sin2);
 
-        z       = gsw_z_from_p(p,lat);
+        z       = gsw_z_from_p(p,lat, 0, 0);
 
         return (gs*(1.0 - gamma*z));    /* z is the height corresponding to p.
                                            Note. In the ocean z is negative. */
@@ -6395,12 +6395,12 @@ function gsw_o2sol(sa, ct, p, lon, lat)
 !==========================================================================
 !
 ! Calculates the oxygen concentration expected at equilibrium with air at
-! an Absolute Pressure of 101325 Pa (sea pressure of 0 dbar) including 
+! an Absolute Pressure of 101325 Pa (sea pressure of 0 dbar) including
 ! saturated water vapor.  This function uses the solubility coefficients
 ! derived from the data of Benson and Krause (1984), as fitted by Garcia
 ! and Gordon (1992, 1993).
 !
-! Note that this algorithm has not been approved by IOC and is not work 
+! Note that this algorithm has not been approved by IOC and is not work
 ! from SCOR/IAPSO Working Group 127. It is included in the GSW
 ! Oceanographic Toolbox as it seems to be oceanographic best practice.
 !
@@ -6452,12 +6452,12 @@ function gsw_o2sol_sp_pt(sp, pt)
 !==========================================================================
 !
 ! Calculates the oxygen concentration expected at equilibrium with air at
-! an Absolute Pressure of 101325 Pa (sea pressure of 0 dbar) including 
+! an Absolute Pressure of 101325 Pa (sea pressure of 0 dbar) including
 ! saturated water vapor.  This function uses the solubility coefficients
 ! derived from the data of Benson and Krause (1984), as fitted by Garcia
 ! and Gordon (1992, 1993).
 !
-! Note that this algorithm has not been approved by IOC and is not work 
+! Note that this algorithm has not been approved by IOC and is not work
 ! from SCOR/IAPSO Working Group 127. It is included in the GSW
 ! Oceanographic Toolbox as it seems to be oceanographic best practice.
 !
@@ -6500,18 +6500,23 @@ gsw_o2sol_sp_pt(double sp, double pt)
 }
 /*
 !==========================================================================
-function gsw_p_from_z(z,lat)
+function gsw_p_from_z(z,lat, geo_strf_dyn_height, sea_surface_geopotential)
 !==========================================================================
 
 ! Calculates the pressure p from height z
 !
 ! z      : height                                          [m]
 ! lat    : latitude                                        [deg]
+! geo_strf_dyn_height : dynamic height anomaly             [m^2/s^2]
+!    Note that the reference pressure, p_ref, of geo_strf_dyn_height must
+!     be zero (0) dbar.
+! sea_surface_geopotental : geopotential at zero sea pressure  [m^2/s^2]
 !
 ! gsw_p_from_z : pressure                                  [dbar]
 */
 double
-gsw_p_from_z(double z, double lat)
+gsw_p_from_z(double z, double lat, double geo_strf_dyn_height,
+             double sea_surface_geopotental)
 {
     GSW_TEOS10_CONSTANTS;
     double sinlat, sin2, gs, c1, p, df_dp, f, p_old, p_mid;
@@ -6529,8 +6534,8 @@ gsw_p_from_z(double z, double lat)
 
     df_dp = db2pa*gsw_specvol_sso_0(p); /* initial value of the derivative of f */
 
-    f = gsw_enthalpy_sso_0(p) + gs*(z - 0.5*gamma*(z*z));
-             /*   - (geo_strf_dyn_height + sea_surface_geopotental); */
+    f = gsw_enthalpy_sso_0(p) + gs*(z - 0.5*gamma*(z*z))
+        - (geo_strf_dyn_height + sea_surface_geopotental);
     p_old = p;
     p = p_old - f/df_dp;
     p_mid = 0.5*(p + p_old);
@@ -9624,17 +9629,17 @@ gsw_sp_from_sstar(double sstar, double p, double lon, double lat)
 !==========================================================================
 function gsw_sp_salinometer(rt,t)
 !==========================================================================
-!  Calculates Practical Salinity SP from a salinometer, primarily using the 
+!  Calculates Practical Salinity SP from a salinometer, primarily using the
 !  PSS-78 algorithm.  Note that the PSS-78 algorithm for Practical Salinity
-!  is only valid in the range 2 < SP < 42.  If the PSS-78 algorithm 
-!  produces a Practical Salinity that is less than 2 then the Practical 
-!  Salinity is recalculated with a modified form of the Hill et al. (1986) 
-!  formula.  The modification of the Hill et al. (1986) expression is to 
-!  ensure that it is exactly consistent with PSS-78 at SP = 2. 
+!  is only valid in the range 2 < SP < 42.  If the PSS-78 algorithm
+!  produces a Practical Salinity that is less than 2 then the Practical
+!  Salinity is recalculated with a modified form of the Hill et al. (1986)
+!  formula.  The modification of the Hill et al. (1986) expression is to
+!  ensure that it is exactly consistent with PSS-78 at SP = 2.
 !
-!  A laboratory salinometer has the ratio of conductivities, Rt, as an 
+!  A laboratory salinometer has the ratio of conductivities, Rt, as an
 !  output, and the present function uses this conductivity ratio and the
-!  temperature t of the salinometer bath as the two input variables. 
+!  temperature t of the salinometer bath as the two input variables.
 !
 !  rt  = C(SP,t_68,0)/C(SP=35,t_68,0)                          [ unitless ]
 !  t   = temperature of the bath of the salinometer,
@@ -9646,7 +9651,7 @@ double
 gsw_sp_salinometer(double rt, double t)
 {
   GSW_SP_COEFFICIENTS;
-  double t68, ft68, rtx, sp, hill_ratio, 
+  double t68, ft68, rtx, sp, hill_ratio,
          x, sqrty, part1, part2, sp_hill_raw;
 
   if (rt < 0){
@@ -11380,18 +11385,23 @@ gsw_util_xinterp1(double *x, double *y, int n, double x0)
 }
 /*
 !==========================================================================
-function gsw_z_from_p(p,lat)
+function gsw_z_from_p(p,lat,geo_strf_dyn_height,sea_surface_geopotental)
 !==========================================================================
 
 ! Calculates the height z from pressure p
 !
 ! p      : sea pressure                                    [dbar]
 ! lat    : latitude                                        [deg]
+! geo_strf_dyn_height : dynamic height anomaly             [m^2/s^2]
+!    Note that the reference pressure, p_ref, of geo_strf_dyn_height must
+!     be zero (0) dbar.
+! sea_surface_geopotental : geopotential at zero sea pressure  [m^2/s^2]
 !
 ! gsw_z_from_p : height                                    [m]
 */
 double
-gsw_z_from_p(double p, double lat)
+gsw_z_from_p(double p, double lat, double geo_strf_dyn_height,
+                double sea_surface_geopotental)
 {
         GSW_TEOS10_CONSTANTS;
         double  x, sin2, b, c, a;
@@ -11400,7 +11410,8 @@ gsw_z_from_p(double p, double lat)
         sin2    = x*x;
         b       = 9.780327*(1.0 + (5.2792e-3 + (2.32e-5*sin2))*sin2);
         a       = -0.5*gamma*b;
-        c       = gsw_enthalpy_sso_0(p);
+        c       = gsw_enthalpy_sso_0(p)
+                  - (geo_strf_dyn_height + sea_surface_geopotental);
 
         return (-2.0*c/(b + sqrt(b*b - 4.0*a*c)));
 }

--- a/gsw_oceanographic_toolbox.c
+++ b/gsw_oceanographic_toolbox.c
@@ -6510,13 +6510,13 @@ function gsw_p_from_z(z,lat, geo_strf_dyn_height, sea_surface_geopotential)
 ! geo_strf_dyn_height : dynamic height anomaly             [m^2/s^2]
 !    Note that the reference pressure, p_ref, of geo_strf_dyn_height must
 !     be zero (0) dbar.
-! sea_surface_geopotental : geopotential at zero sea pressure  [m^2/s^2]
+! sea_surface_geopotential : geopotential at zero sea pressure  [m^2/s^2]
 !
 ! gsw_p_from_z : pressure                                  [dbar]
 */
 double
 gsw_p_from_z(double z, double lat, double geo_strf_dyn_height,
-             double sea_surface_geopotental)
+             double sea_surface_geopotential)
 {
     GSW_TEOS10_CONSTANTS;
     double sinlat, sin2, gs, c1, p, df_dp, f, p_old, p_mid;
@@ -6535,7 +6535,7 @@ gsw_p_from_z(double z, double lat, double geo_strf_dyn_height,
     df_dp = db2pa*gsw_specvol_sso_0(p); /* initial value of the derivative of f */
 
     f = gsw_enthalpy_sso_0(p) + gs*(z - 0.5*gamma*(z*z))
-        - (geo_strf_dyn_height + sea_surface_geopotental);
+        - (geo_strf_dyn_height + sea_surface_geopotential);
     p_old = p;
     p = p_old - f/df_dp;
     p_mid = 0.5*(p + p_old);
@@ -11385,7 +11385,7 @@ gsw_util_xinterp1(double *x, double *y, int n, double x0)
 }
 /*
 !==========================================================================
-function gsw_z_from_p(p,lat,geo_strf_dyn_height,sea_surface_geopotental)
+function gsw_z_from_p(p,lat,geo_strf_dyn_height,sea_surface_geopotential)
 !==========================================================================
 
 ! Calculates the height z from pressure p
@@ -11395,13 +11395,13 @@ function gsw_z_from_p(p,lat,geo_strf_dyn_height,sea_surface_geopotental)
 ! geo_strf_dyn_height : dynamic height anomaly             [m^2/s^2]
 !    Note that the reference pressure, p_ref, of geo_strf_dyn_height must
 !     be zero (0) dbar.
-! sea_surface_geopotental : geopotential at zero sea pressure  [m^2/s^2]
+! sea_surface_geopotential : geopotential at zero sea pressure  [m^2/s^2]
 !
 ! gsw_z_from_p : height                                    [m]
 */
 double
 gsw_z_from_p(double p, double lat, double geo_strf_dyn_height,
-                double sea_surface_geopotental)
+                double sea_surface_geopotential)
 {
         GSW_TEOS10_CONSTANTS;
         double  x, sin2, b, c, a;
@@ -11411,7 +11411,7 @@ gsw_z_from_p(double p, double lat, double geo_strf_dyn_height,
         b       = 9.780327*(1.0 + (5.2792e-3 + (2.32e-5*sin2))*sin2);
         a       = -0.5*gamma*b;
         c       = gsw_enthalpy_sso_0(p)
-                  - (geo_strf_dyn_height + sea_surface_geopotental);
+                  - (geo_strf_dyn_height + sea_surface_geopotential);
 
         return (-2.0*c/(b + sqrt(b*b - 4.0*a*c)));
 }

--- a/gswteos-10.h
+++ b/gswteos-10.h
@@ -300,9 +300,11 @@ extern double *gsw_util_linear_interp(int nx, double *x, int ny, double *y,
 extern void   gsw_util_sort_real(double *rarray, int nx, int *iarray);
 extern double gsw_util_xinterp1(double *x, double *y, int n, double x0);
 extern int gsw_util_pchip_interp(double *x, double *y, int n,
-                                     double *xi, double *yi, int ni);
-extern double gsw_z_from_p(double p, double lat);
-extern double gsw_p_from_z(double z, double lat);
+                double *xi, double *yi, int ni);
+extern double gsw_z_from_p(double p, double lat, double geo_strf_dyn_height,
+                double sea_surface_geopotental);
+extern double gsw_p_from_z(double z, double lat, double geo_strf_dyn_height,
+                double sea_surface_geopotental);
 
 #ifdef __cplusplus
 }

--- a/gswteos-10.h
+++ b/gswteos-10.h
@@ -302,9 +302,9 @@ extern double gsw_util_xinterp1(double *x, double *y, int n, double x0);
 extern int gsw_util_pchip_interp(double *x, double *y, int n,
                 double *xi, double *yi, int ni);
 extern double gsw_z_from_p(double p, double lat, double geo_strf_dyn_height,
-                double sea_surface_geopotental);
+                double sea_surface_geopotential);
 extern double gsw_p_from_z(double z, double lat, double geo_strf_dyn_height,
-                double sea_surface_geopotental);
+                double sea_surface_geopotential);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The two arguments, geo_strf_dyn_height and sea_surface_geopotential,
are not used internally and are optional in the Matlab and Fortran
versions.  They will also be optional in the Python version.  C support
for optional arguments is less straightforward than in the other
languages, so we stick with the simple 4-argument signature instead.