### PR TITLE
Bring lons outside of [0, 360) into range

### DIFF
--- a/gsw_check_functions.c
+++ b/gsw_check_functions.c
@@ -137,6 +137,16 @@ main(int argc, char **argv)
         test_func(sstar_from_sp,(sp[i],p[i],lon[i],lat[i]),value,sstar_from_sp);
         test_func(ct_from_t, (sa[i],t[i],p[i]), value,ct_from_t);
 
+        // the baltic sea calculations have a lon range assumption in them
+        for (i = 0; i<count; i++) {
+            value[i] = gsw_sa_from_sp(sp[i],p[i],lon[i]+360.,lat[i]);
+        }
+        check_accuracy("sa_from_sp_lon_wrapped_high",sa_from_sp_ca,"sa_from_sp",count,value,sa_from_sp);
+        for (i = 0; i<count; i++) {
+            value[i] = gsw_sa_from_sp(sp[i],p[i],lon[i]-720.,lat[i]);
+        }
+        check_accuracy("sa_from_sp_lon_wrapped_low",sa_from_sp_ca,"sa_from_sp",count,value,sa_from_sp);
+
         section_title(
           "Other conversions between Temperatures, Salinities, Entropy, "
           "Pressure and Height");
@@ -146,6 +156,17 @@ main(int argc, char **argv)
         test_func(sr_from_sp, (sp[i]), sr,sr_from_sp);
         test_func(sp_from_sr, (sr[i]), value,sp_from_sr);
         test_func(sp_from_sa, (sa[i],p[i],lon[i],lat[i]), value,sp_from_sa);
+
+        // the baltic sea calculations have a lon range assumption in them
+        for (i = 0; i<count; i++) {
+            value[i] = gsw_sp_from_sa(sa[i],p[i],lon[i]+360.,lat[i]);
+        }
+        check_accuracy("ssp_from_sa_lon_wrapped_high",sp_from_sa_ca,"sp_from_sa",count,value,sp_from_sa);
+        for (i = 0; i<count; i++) {
+            value[i] = gsw_sp_from_sa(sa[i],p[i],lon[i]-720.,lat[i]);
+        }
+        check_accuracy("sa_from_sp_lon_wrapped_low",sp_from_sa_ca,"sp_from_sa",count,value,sp_from_sa);
+
         test_func(sstar_from_sa,(sa[i],p[i],lon[i],lat[i]),sstar,sstar_from_sa);
         test_func(sa_from_sstar, (sstar[i],p[i],lon[i],lat[i]), value,
             sa_from_sstar);
@@ -332,6 +353,25 @@ main(int argc, char **argv)
 
         test_func(deltasa_atlas, (p[i],lon[i],lat[i]),value,deltasa_atlas);
         test_func(fdelta, (p[i],lon[i],lat[i]),value,fdelta);
+
+        // wrap the lons a bit to check wrapping
+        for (i = 0; i<count; i++) {
+            value[i] = gsw_deltasa_atlas(p[i],lon[i]+360.,lat[i]);
+        }
+        check_accuracy("deltasa_atlas_lon_wrapped_high",deltasa_atlas_ca,"deltasa_atlas",count,value,deltasa_atlas);
+        for (i = 0; i<count; i++) {
+            value[i] = gsw_deltasa_atlas(p[i],lon[i]-720.,lat[i]);
+        }
+        check_accuracy("deltasa_atlas_lon_wrapped_low",deltasa_atlas_ca,"deltasa_atlas",count,value,deltasa_atlas);
+
+        for (i = 0; i<count; i++) {
+            value[i] = gsw_fdelta(p[i],lon[i]+360.,lat[i]);
+        }
+        check_accuracy("fdelta_lon_wrapped_high",fdelta_ca,"fdelta",count,value,fdelta);
+        for (i = 0; i<count; i++) {
+            value[i] = gsw_fdelta(p[i],lon[i]-720.,lat[i]);
+        }
+        check_accuracy("fdelta_lon_wrapped_low",fdelta_ca,"fdelta",count,value,fdelta);
 
         section_title(
             "Water column properties, based on the 75-term polynomial "

--- a/gsw_oceanographic_toolbox.c
+++ b/gsw_oceanographic_toolbox.c
@@ -9024,6 +9024,10 @@ gsw_sa_from_sp_baltic(double sp, double lon, double lat)
         GSW_BALTIC_DATA;
         double  xx_left, xx_right, return_value;
 
+        lon = fmod(lon, 360.0);
+        if (lon < 0.0)
+            lon += 360.0;
+
         if (xb_left[1] < lon  && lon < xb_right[0]  && yb_left[0] < lat  &&
             lat < yb_left[2]) {
 
@@ -9566,6 +9570,10 @@ gsw_sp_from_sa_baltic(double sa, double lon, double lat)
         GSW_TEOS10_CONSTANTS;
         GSW_BALTIC_DATA;
         double  xx_left, xx_right, return_value;
+
+        lon = fmod(lon, 360.0);
+        if (lon < 0.0)
+            lon += 360.0;
 
         if (xb_left[1] < lon  && lon < xb_right[0]  && yb_left[0] < lat  &&
             lat < yb_left[2]) {

--- a/gsw_saar.c
+++ b/gsw_saar.c
@@ -60,6 +60,7 @@ gsw_saar(double p, double lon, double lat)
     if (lat < -86.0 || lat > 90.0)
         return (return_value);
 
+    lon = fmod(lon, 360.0);
     if (lon < 0.0)
         lon += 360.0;
 
@@ -184,6 +185,7 @@ gsw_deltasa_atlas(double p, double lon, double lat)
     if (lat < -86.0 || lat > 90.0)
         return (return_value);
 
+    lon = fmod(lon, 360.0);
     if (lon < 0.0)
         lon += 360.0;
 


### PR DESCRIPTION
This is an attempt at solving #46 including tests.

There were 4 places that an fmod call appeared to be needed, the two saar lookup functions, and the Baltic sea specific functions.

It does not appear to be immediately needed in `gsw_add_barrier` as that is only called by the saar functions which already are brought into range by this PR.