### PR TITLE
add workflow_dispatch option to GitHub workflows

### DIFF
--- a/.github/workflows/nix-tests.yml
+++ b/.github/workflows/nix-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   run:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   pre-commit:

--- a/.github/workflows/win-tests.yml
+++ b/.github/workflows/win-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   run:


### PR DESCRIPTION
This small addition should allow contributors to test all your workflows in their own forks, regardless of the branch name.