### PR TITLE
add a meson.build file, tests and update the README.MD

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,7 +3,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-alternative-compilers.yml
+++ b/.github/workflows/test-alternative-compilers.yml
@@ -3,7 +3,7 @@ name: run gsw_check (alternative compilers)
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-alternative-compilers.yml
+++ b/.github/workflows/test-alternative-compilers.yml
@@ -3,7 +3,7 @@ name: run gsw_check (alternative compilers)
 on:
   pull_request:
   push:
-    #branches: [master]
+    branches: [master]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests-meson.yml
+++ b/.github/workflows/tests-meson.yml
@@ -3,7 +3,7 @@ name: test meson wrapper
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tests-meson.yml
+++ b/.github/workflows/tests-meson.yml
@@ -1,0 +1,58 @@
+name: test meson wrapper
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  run:
+    name: lib${{ matrix.library }} ${{ matrix.compiler }} ${{ matrix.os }} ${{ matrix.force_cpp }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        library: ["static", "shared"]
+        compiler: ["gcc", "clang", "cl", "clang-cl"]
+        force_cpp: [-Dforce-cpp=enabled, ""]
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        exclude:
+          - os: windows-latest
+            compiler: "clang"
+          - os: windows-latest
+            compiler: "gcc"
+          - os: windows-latest
+            force_cpp: "-Dforce-cpp=enabled"
+          - os: ubuntu-latest
+            compiler: "cl"
+          - os: ubuntu-latest
+            compiler: "clang-cl"
+          - os: macos-latest
+            compiler: "cl"
+          - os: macos-latest
+            compiler: "clang-cl"
+
+      fail-fast: false
+
+    env:
+      CC: ${{matrix.compiler}}
+      CXX: ${{matrix.compiler}}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: install dependencies
+        run: python -m pip install meson ninja
+
+      - name: Compile
+        run: |
+          meson setup builddir -Ddefault_library=${{matrix.library}} ${{matrix.force_cpp}}
+          meson compile -C builddir
+
+      - name: Test
+        run: |
+          meson test -C builddir --print-errorlogs -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: run gsw_check
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/README
+++ b/README
@@ -33,6 +33,10 @@ Makefile                        -- basic make file to build gsw_check and
                                     libgswteos-10.so
 TOOLS.ini                       -- Variable definitions used by nmake
 TOOLS.gcc                       -- Variable definitions used by make
+meson.build                     -- Meson build file (alternative build system to build
+                                    libgswteos-10 library and gsw_check tests)
+meson.options                   -- Meson build options file (defines additional options
+                                   for the Meson build system)
 
 Usage (Unix / make):
 --------------------

--- a/README
+++ b/README
@@ -1,5 +1,7 @@
+Original README
+###############
 
-TEOS-10 V3.05 GSW Oceanographic Toolbox in C
+TEOS-10 V3.06 GSW Oceanographic Toolbox in C
 ============================================
 
 This began as a translation of the original Fortran-90 source code into C.  Unlike
@@ -32,8 +34,8 @@ Makefile                        -- basic make file to build gsw_check and
 TOOLS.ini                       -- Variable definitions used by nmake
 TOOLS.gcc                       -- Variable definitions used by make
 
-Usage (Unix):
-------
+Usage (Unix / make):
+--------------------
 
 The C GSW Oceanographic Toolbox comes with a testing program, gsw_check.  In the
 directory that the toolbox was unpacked, type:
@@ -47,8 +49,8 @@ If gsw_check builds successfully, run it to test the toolbox:
 
     ./gsw_check
 
-Usage (Windows):
-------
+Usage (Windows / nmake):
+------------------------
 In the directory that the toolbox was unpacked, type:
 
     nmake
@@ -60,6 +62,29 @@ should be set manually.
 If gsw_check builds successfully, run it to test the toolbox:
 
     gsw_check.exe
+
+Usage (meson build system):
+---------------------------
+
+We provide a meson.build file (https://mesonbuild.com/) for GSW-C that works
+on Linux, Mac, and Windows.
+To setup a build directory and install the library and headers:
+
+    meson setup builddir
+    meson install -C builddir
+
+This will install gswteos-10.h, a shared library libgswteos-10 and a package
+config file gswteos-10.pc.
+
+Meson can be configured with options like prefix, default_library etc.:
+
+    meson setup builddir -Dprefix=/usr/local -Ddefault_library=static -Dbuildtype=release
+    meson install -C builddir
+
+For more options see mesonbuild.com. To run the tests use:
+
+    meson test -C builddir -v
+
 
 Notes:
 ------

--- a/README-developer
+++ b/README-developer
@@ -24,6 +24,10 @@ gsw_check_functions.c   -- C implementation of the check functions used
                             Oceanographic Toolbox.
 TOOLS.ini               -- Variable definitions used by nmake
 TOOLS.gcc               -- Variable definitions used by make
+meson.build             -- Meson build file (alternative build system to build
+                            libgswteos-10 library and gsw_check tests)
+meson.options           -- Meson build options file (defines additional options
+                            for the Meson build system)
 
 Files for development
 =====================
@@ -48,6 +52,8 @@ gsw_data_ncdump.txt     -- Edited text from the "ncdump -h" of a netcdf file
                             an earlier version of gsw_data_v3_0.mat.  It is
                             used by make_data_from_mat.py to find the array
                             dimensions when generating gsw_check_data.nc.
+meson.options           -- Meson build options file. Use this to define more
+                            options for the Meson build system. (e.g. force-cpp)
 
 Notes for contributors
 ======================

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,103 @@
+
+
+# SPDX-FileCopyrightText: 2024 Peter Urban
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# 'TEOS-10 V3.06.16-0 GSW Oceanographic Toolbox in C'
+# 'http://teos-10.org'
+
+# --- Project ---
+# Define project meta data
+project(
+  'gswteos-10',
+  ['c', 'cpp'], #appears to be c on linux/mac and cpp on windows
+  license: 'BSD-3-Clause',
+
+  version: 'v3.06.16-0',
+  default_options: ['warning_level=2', 'buildtype=release'],
+  meson_version: '>=1.5.1' #latest tested version,,,,
+)
+
+project_name = 'gswteos-10'
+description = 'TEOS-10 V3.06.16-0 GSW Oceanographic Toolbox in C'
+url = 'http://teos-10.org'
+
+# --- dependencies ---
+# libm (math library)
+# Required is set to false because libm is only necessary and available if
+# it is not already included in the compiler (e.g. gcc/linux)
+cc = meson.get_compiler('c')
+m_dep = cc.find_library('m', required: false)
+
+# --- compile options ---
+c_compile_args = []
+cpp_compile_args = []
+
+# Force compile language to be c++ on windows (cl and clang-cl) (or if force-cpp option is enabled)
+link_language = 'c'
+if cc.get_id() == 'cl' or cc.get_id() == 'msvc' or cc.get_id() == 'clang-cl'
+  message('Setting /Tp flag to interpret c files as c++ files on windows')
+  cpp_compile_args += ['/TP'] #interpret c files as c++ files on windows
+  c_compile_args += ['/TP'] #interpret c files as c++ files on windows
+  link_language = 'cpp'
+elif get_option('force-cpp').enabled()
+  if cc.get_id() == 'gcc' or cc.get_id() == 'clang'
+    c_compile_args += ['-xc++']
+  else
+    error('Unhandled compiler id: ' + cc.get_id() + '! Cannot enable option force-cpp')
+  endif
+endif
+
+# --- sources ---
+program_sources = ['gsw_check_functions.c']
+
+library_sources = [
+  'gsw_oceanographic_toolbox.c',
+  'gsw_saar.c',
+]
+
+export_headers = ['gswteos-10.h']
+
+# --- define library and dependencies ---
+gswteos_10_lib = library(
+  project_name,
+  library_sources,
+  c_args: c_compile_args,
+  cpp_args: cpp_compile_args,
+  dependencies: [m_dep],
+  link_language: link_language,
+  install: true,
+)
+
+gswteos_10_dep = declare_dependency(
+  dependencies: [m_dep],
+  link_with: [gswteos_10_lib],
+  include_directories: include_directories('.'),
+)
+
+# --- Installation ---
+# install headers
+install_headers(export_headers)
+
+# pkgconfig file
+pkg = import('pkgconfig')
+pkg.generate(
+  description: description,
+  url: url,
+  version: meson.project_version(),
+  name: project_name,
+  libraries: gswteos_10_lib,
+)
+
+# --- define tests ---
+gswteos_10_exe = executable(
+  'gsw_check',
+  sources: [program_sources],
+  dependencies: [gswteos_10_dep],
+  c_args: c_compile_args,
+  cpp_args: cpp_compile_args,
+  link_language: link_language,
+)
+
+test('run_gsw_check', gswteos_10_exe)

--- a/meson.build
+++ b/meson.build
@@ -11,7 +11,7 @@
 # Define project meta data
 project(
   'gswteos-10',
-  ['c', 'cpp'], #appears to be c on linux/mac and cpp on windows
+  ['c', 'cpp'], #language is c on linux/mac and cpp on windows
   license: 'BSD-3-Clause',
 
   version: 'v3.06.16-0',

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,1 @@
+option('force-cpp', type: 'feature', value: 'disabled', description: 'If enabled, C files will be compiled as C++')


### PR DESCRIPTION
This adds a meson.build file (see issue https://github.com/TEOS-10/GSW-C/issues/72)
I also added a related test matrix updated the README.MD to report how to build the project using meson.

The build file allows installing and testing the project using different configurations.
When installing, it also installs a package config file which should ease integrating with e.g. CMAKE 
However I didn't actually test the package config file (Happy to support you if you run into problems though)

The build file also allows for directly integrating the project as subproject into existing meson 
projects (this is what I use it for at the moment)

Happy to receive feedback on this PR, I'd also be happy to support maintaining this file.
Cheers
