### PR TITLE
remove macos-gcc and linux-clang compiler configurations from tests

### DIFF
--- a/.github/workflows/test-alternative-compilers.yml
+++ b/.github/workflows/test-alternative-compilers.yml
@@ -21,24 +21,6 @@ jobs:
               compiler: 'g++'
               extra_flags: "-x c++"
               make_command: 'make CC=$CC EXTRA_FLAGS="$EXTRA_FLAGS"'
-            - name: linux / clang (c)
-              os: ubuntu-latest
-              compiler: 'clang'
-              make_command: 'make CC=$CC'
-            - name: linux / clang (c++)
-              os: ubuntu-latest
-              compiler: 'clang'
-              extra_flags: "-x c++"
-              make_command: 'make CC=$CC EXTRA_FLAGS="$EXTRA_FLAGS"'
-            - name: macos / g++ (c++)
-              os: macos-latest
-              compiler: 'g++'
-              extra_flags: "-x c++"
-              make_command: 'make CC=$CC EXTRA_FLAGS="$EXTRA_FLAGS"'
-            - name: macos / clang (c)
-              os: macos-latest
-              compiler: 'clang'
-              make_command: 'make CC=$CC'
             - name: macos / clang (c++)
               os: macos-latest
               compiler: 'clang'

--- a/.github/workflows/tests-meson.yml
+++ b/.github/workflows/tests-meson.yml
@@ -27,10 +27,14 @@ jobs:
             compiler: "cl"
           - os: ubuntu-latest
             compiler: "clang-cl"
+          - os: ubuntu-latest
+            compiler: "clang"
           - os: macos-latest
             compiler: "cl"
           - os: macos-latest
             compiler: "clang-cl"
+          - os: macos-latest
+            compiler: "gcc"
 
       fail-fast: false
 


### PR DESCRIPTION
See https://github.com/TEOS-10/GSW-C/issues/77

This is a first measure to reduce the number of test cases:
- I removed all macos - gcc configurations (calling gcc on macos seems to call clang anyways)
- I removed all linux - clang configurations (I think it is safe enough to assume that clang works similar enough on linux and mac. Clang compiler problems on linu,x that are not found on mac should probably be reported to llvm directly and not to GSW-C