### PR TITLE
Set warning level to 0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,8 +15,8 @@ project(
   license: 'BSD-3-Clause',
 
   version: 'v3.06.16-0',
-  default_options: ['warning_level=2', 'buildtype=release'],
-  meson_version: '>=1.5.1' #latest tested version,,,,
+  default_options: ['warning_level=0', 'buildtype=release'],
+  meson_version: '>=1.5.1' #latest tested version
 )
 
 project_name = 'gswteos-10'


### PR DESCRIPTION
Related to https://github.com/TEOS-10/GSW-C/issues/77

The reason why the meson test suit produces more errors than the makefile, is that the warning level was set to 2 (my fault). Explanation on meson [warning levels](https://github.com/TEOS-10/GSW-C/issues/77): 

Warning level 1 flags:   -Wall                      
Warning level 2 flags:   -Wall -Wextra    
Warning level 3 flags::  -Wall -Wextra -Wpedantic

It may be good to discuss the desired warning flags in a future issue, but for now meson.build should just reproduce the same results as the makefile