### PR TITLE
Fix sprintf is deprecated (macos / clang / c++)

### DIFF
--- a/gsw_check_functions.c
+++ b/gsw_check_functions.c
@@ -660,7 +660,7 @@ report(const char *funcname, const char *varname, gsw_error_info *errs)
             }
             strcat(message, ")");
         }
-        sprintf(infoflg,"(%s%3d)",(errs->flags & GSW_ERROR_LIMIT_FLAG)?"*":"",
+        snprintf(infoflg, sizeof(infoflg), "(%s%3d)", (errs->flags & GSW_ERROR_LIMIT_FLAG)?"*":"",
                 errs->ncomp);
         ndots = 65 - strlen(message);
         if (errs->flags & GSW_ERROR_ERROR_FLAG) {


### PR DESCRIPTION
Relates to https://github.com/TEOS-10/GSW-C/issues/77

Fixes warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.
The warning occurs in the alternative compilers test suit / macos / clang c++

The fix seems innocent enough (sizeof(infoflg) needs to be passed to snprintf)