### PR TITLE
Set _CRT_SECURE_NO_WARNINGS in gsw_check_functions.c

### DIFF
--- a/gsw_check_functions.c
+++ b/gsw_check_functions.c
@@ -2,6 +2,14 @@
 **  $Id: gsw_check_functions.c,v 0db1b20bdf1b 2015/08/26 21:39:20 fdelahoyde $
 **  $Version: 3.05.0-1 $
 */
+
+/* This ignores MSVC warnings about "unsafe: functions (strcpy, strncat,
+** strcat) in the gsw_check_functions.c file . While the security advice
+** may be sound in the context of the main library, these functions do not pose
+** a security risk in the context of this test executable.
+*/
+#define _CRT_SECURE_NO_WARNINGS
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>


### PR DESCRIPTION
Relates to https://github.com/TEOS-10/GSW-C/issues/77

Compiling on windows (with clang-cl or with msvc on a higher warning level) creates a number of these warnings

```
warning: 'strcat' is deprecated: This function or variable may be unsafe. Consider using strcat_s instead.
```

It would be possible with to replace the strcat, strncat and strcpy functions by strcat_s etc. However, these functions only appear in gsw_check_functions.c. And personally I don't think increasing memory safety / security is something to worry about in this test executable.

defining _CRT_SECURE_NO_WARNINGS ignores these msvc/windows specific "security" warnings. Since _CRT_SECURE_NO_WARNINGS is only defined in the gsw_check_functions.c, the warnings would still be displayed if these functions would be used within the main library.

If you disagree let me know, I can certainly ask co-pilot to show me how to replace strcat with strcat_s ;-)